### PR TITLE
Cast tweetid to string

### DIFF
--- a/lambdas/src/dynamo_lambda/main.py
+++ b/lambdas/src/dynamo_lambda/main.py
@@ -17,13 +17,13 @@ table = dynamodb.Table('cdk-twitter-dynamo')
 def handler(event: dict, context):
     if event:
         username: str = event['username'].lower()
-        tweet_id: int = event['tweet_id']
+        tweet_id: str = event['tweet_id']
         video_link: str = event['video_link']
 
         write_tweet_to_db(username, tweet_id, video_link)
 
 
-def write_tweet_to_db(username: str, tweet_id: int, video_link: str):
+def write_tweet_to_db(username: str, tweet_id: str, video_link: str):
     user_document: dict = get_document(username)
     expiration_date = int(time.time()) + (int(expiration_days) * 86400)
 
@@ -43,7 +43,7 @@ def get_document(username: str):
     return document
 
 
-def update_user_document(username: str, tweet_id: int, video_link: str, number_of_existing_tweets: int, expiration_date: int):
+def update_user_document(username: str, tweet_id: str, video_link: str, number_of_existing_tweets: int, expiration_date: int):
     """
     If the document already has 5 tweets saved,
     this will first remove the oldest of them
@@ -76,7 +76,7 @@ def update_user_document(username: str, tweet_id: int, video_link: str, number_o
     return update
 
 
-def put_new_user_document(username: str, tweet_id: int, video_link: str, expiration_date: int):
+def put_new_user_document(username: str, tweet_id: str, video_link: str, expiration_date: int):
     put_id = table.put_item(
         Item={
             'username': username,

--- a/lambdas/src/twitter_lambda/main.py
+++ b/lambdas/src/twitter_lambda/main.py
@@ -44,7 +44,7 @@ def reply_to_statuses(search: tweepy.models.SearchResults):
 
     if search:
         for result in search:
-            tweet_id: int = result._json['id']
+            tweet_id: str = str(result._json['id'])
             parent_tweet_id: int = result._json['in_reply_to_status_id']
             user_screen_name: str = result._json['user']['screen_name']
             parent_tweet_data: tweepy.models.Status = api.get_status(parent_tweet_id, tweet_mode='extended')
@@ -82,7 +82,7 @@ def return_highest_bitrate(parent_tweet_data: tweepy.models.Status):
         return None
 
 
-def invoke_dynamo_lambda(tweet_id: int, user_screen_name: str, video_link: str):
+def invoke_dynamo_lambda(tweet_id: str, user_screen_name: str, video_link: str):
     response = client.invoke(
     FunctionName=f'arn:aws:lambda:{region}:{account_id}:function:cdk-dynamo-lambda',
     InvocationType='RequestResponse',


### PR DESCRIPTION
WHAT

Casting tweet id to string

WHY

When the client returns the tweet data from dynamo, because tweet id is a long number, it rounds it down. It needs to be accurate so the front end can link to the original tweet, so I'm casting it as a string here, rather than have this casting on the client side.